### PR TITLE
For HRE creating a seperate table and load data

### DIFF
--- a/src/scripts/sql/HRE_create_table_and_load_data.psql
+++ b/src/scripts/sql/HRE_create_table_and_load_data.psql
@@ -1,0 +1,3 @@
+\i truncatedroptable.sql
+\i create_canada_food_guide_food_item.sql
+\i insertCFGDataFinal2015.sql


### PR DESCRIPTION
This file is created to deal with a scenario when deploying to HRE. Currently we have a script to drop the database instance, create a new instance and then run the create_table_and_load_data.psql

However, with the file specifying a DB instance to connect to, our build fails. Hard coding the DB name is problematic for deployment. In addition, the maser create_table_and_load_data.psql also drops and recreates cnfadm-qa which could potentially be disruptive since if the cfg-task-service DB instance is being rebuild, one does not want to rebuild the cfg-task-service-qa DB instance